### PR TITLE
fix(): workflow id for child and deprecate WorkflowSignal

### DIFF
--- a/queues/defs.go
+++ b/queues/defs.go
@@ -1,7 +1,23 @@
 package queues
 
+import (
+	"encoding/json"
+)
+
 type (
+	// WorkflowSignal is a string alias intended for defining groups of workflow signals.
+	//
+	// Depraecated: Use Signal instead.
 	WorkflowSignal string
+
+	// Signal is a string alias intended for defining groups of workflow signals, "register" , "send_welcome_email" etc.
+	// It ensures consistency and code clarity. The Signal type provides methods for conversion and serialization,
+	// promoting good developer experience.
+	Signal string
+
+	// Query is a string alias intended for defining groups of workflow queries. We could have created an alias for
+	// for Signal type, but for some wierd reason, if was causing temporal to panic when marshalling the type to JSON.
+	Query string
 )
 
 func (s WorkflowSignal) String() string {
@@ -9,10 +25,54 @@ func (s WorkflowSignal) String() string {
 }
 
 func (s WorkflowSignal) MarshalJSON() ([]byte, error) {
-	return []byte(s.String()), nil
+	return json.Marshal(string(s))
 }
 
 func (s *WorkflowSignal) UnmarshalJSON(data []byte) error {
-	*s = WorkflowSignal(data)
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	*s = WorkflowSignal(str)
+
+	return nil
+}
+
+func (s Signal) String() string {
+	return string(s)
+}
+
+func (s Signal) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(s))
+}
+
+func (s *Signal) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	*s = Signal(str)
+
+	return nil
+}
+
+func (q Query) String() string {
+	return string(q)
+}
+
+func (q Query) MarshalJSON() ([]byte, error) {
+	return json.Marshal(string(q))
+}
+
+func (q *Query) UnmarshalJSON(data []byte) error {
+	var str string
+	if err := json.Unmarshal(data, &str); err != nil {
+		return err
+	}
+
+	*q = Query(str)
+
 	return nil
 }

--- a/queues/queues_test.go
+++ b/queues/queues_test.go
@@ -128,7 +128,7 @@ func (s *QueueTestSuite) TestExecuteChildWorkflow() {
 func (s *QueueTestSuite) TestSignalWorkflow() {
 	ctx := context.Background()
 	id := uuid.New()
-	name := queues.WorkflowSignal("signal")
+	name := queues.Signal("signal")
 	opts, _ := workflows.NewOptions(
 		workflows.WithBlock("signal"),
 		workflows.WithBlockID(id.String()),

--- a/workflows/options.go
+++ b/workflows/options.go
@@ -13,11 +13,11 @@ const (
 type (
 	// Options defines the interface for creating workflow options.
 	Options interface {
-		IsChild() bool                     // IsChild returns true if the workflow id is a child workflow id.
-		ParentWorkflowID() (string, error) // ParentWorkflowID returns the parent workflow id.
-		IDSuffix() string                  // IDSuffix santizes the suffix of the workflow id and then formats it as a string.
-		MaxAttempts() int32                // MaxAttempts returns the max attempts for the workflow.
-		IgnoredErrors() []string           // IgnoredErrors returns the list of errors that are ok to ignore.
+		IsChild() bool            // IsChild returns true if the workflow id is a child workflow id.
+		ParentWorkflowID() string // ParentWorkflowID returns the parent workflow id.
+		IDSuffix() string         // IDSuffix santizes the suffix of the workflow id and then formats it as a string.
+		MaxAttempts() int32       // MaxAttempts returns the max attempts for the workflow.
+		IgnoredErrors() []string  // IgnoredErrors returns the list of errors that are ok to ignore.
 	}
 
 	// Option sets the specified options.
@@ -27,8 +27,6 @@ type (
 	props map[string]string
 
 	options struct {
-		parent_context workflow.Context // The parent workflow context.
-
 		ParentID       string   `json:"parent"`          // The parent workflow ID.
 		Block          string   `json:"block"`           // The block name.
 		BlockID        string   `json:"block_id"`        // The block identifier.
@@ -48,14 +46,9 @@ func (w *options) IsChild() bool {
 	return w.ParentID != ""
 }
 
-func (w *options) ID() string {
-	id := w.IDSuffix()
-
-	if w.IsChild() {
-		return w.ParentID + "." + id
-	}
-
-	return id
+// ParentWorkflowID returns the parent workflow id.
+func (w *options) ParentWorkflowID() string {
+	return w.ParentID
 }
 
 // IDSuffix sanitizes the suffix and returns it.
@@ -75,15 +68,6 @@ func (w *options) IDSuffix() string {
 	}
 
 	return strings.Join(sanitized, ".")
-}
-
-// ParentWorkflowID returns the parent workflow id.
-func (w *options) ParentWorkflowID() (string, error) {
-	if w.parent_context == nil {
-		return "", ErrParentNil
-	}
-
-	return workflow.GetInfo(w.parent_context).WorkflowExecution.ID, nil
 }
 
 // MaxAttempts returns the max attempts for the workflow.

--- a/workflows/options_test.go
+++ b/workflows/options_test.go
@@ -13,12 +13,11 @@ func TestWorkflowMod(t *testing.T) {
 		workflows.WithMod("mod"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "mod", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 
 func TestWorkflowModWithID(t *testing.T) {
@@ -27,12 +26,11 @@ func TestWorkflowModWithID(t *testing.T) {
 		workflows.WithModID("modid"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "mod.modid", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 
 func TestWorkflowElement(t *testing.T) {
@@ -40,12 +38,11 @@ func TestWorkflowElement(t *testing.T) {
 		workflows.WithElement("elm"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "elm", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 
 func TestWorkflowElementWithID(t *testing.T) {
@@ -54,12 +51,11 @@ func TestWorkflowElementWithID(t *testing.T) {
 		workflows.WithElementID("elmid"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "elm.elmid", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 
 func TestWorkflowBlock(t *testing.T) {
@@ -67,12 +63,11 @@ func TestWorkflowBlock(t *testing.T) {
 		workflows.WithBlock("block"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "block", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 
 func TestWorkflowBlockWithID(t *testing.T) {
@@ -81,12 +76,11 @@ func TestWorkflowBlockWithID(t *testing.T) {
 		workflows.WithBlockID("blockid"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "block.blockid", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 
 func TestWithProp(t *testing.T) {
@@ -100,12 +94,11 @@ func TestWithProp(t *testing.T) {
 		workflows.WithProp("prop", "value"),
 	)
 
-	parent, err := workflow.ParentWorkflowID()
+	parent := workflow.ParentWorkflowID()
 	suffix := workflow.IDSuffix()
 
 	assert.Equal(t, "block.blockid.elm.elmid.mod.modid.prop.value", suffix)
 	assert.Equal(t, "", parent)
-	assert.ErrorIs(t, err, workflows.ErrParentNil)
 }
 func TestWithPropMultiple(t *testing.T) {
 	workflow, _ := workflows.NewOptions(


### PR DESCRIPTION
This pull request fixes the workflow id for child workflows and deprecates the use of `WorkflowSignal` in favor of `Signal`. The `WorkflowSignal` type is now aliased to `Signal` for better code clarity and consistency. Additionally, the `Options` interface has been updated to return the parent workflow id as a string instead of returning an error.